### PR TITLE
Updated regex to fix file name issue and added IAM support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.1.6 - 2023-12-07
+
+### Added
+
+- Merged support for IAM profiles. See [Issue #44](https://github.com/timmyomahony/craft-remote-backup/issues/44).
+
+### Fixed
+
+- Simplified the regex to accept all characters in the system name & env. Hopefully avoiding further interface errors. See [Issue #49](https://github.com/timmyomahony/craft-remote-backup/issues/49)
+
 ## 4.1.5 - 2023-10-26
 
 ### Changed

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,4 @@
 {
-    "minimum-stability": "dev",
     "name": "weareferal/remote-backup",
     "description": "Backup your database and assets to a remote location",
     "type": "craft-plugin",
@@ -24,17 +23,8 @@
     "require": {
         "craftcms/cms": "^4.0.0",
         "php": "^8.0.2",
-        "weareferal/remote-core": "dev-develop"
+        "weareferal/remote-core": "4.1.2"
     },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../craft-remote-core",
-            "options": {
-                "symlink": true
-            }
-        }
-    ],
     "require-dev": {
         "phpstan/phpstan": "1.8.x-dev",
         "craftcms/phpstan": "dev-main",


### PR DESCRIPTION
## Added

- Merged support for IAM profiles. See [Issue #44](https://github.com/timmyomahony/craft-remote-backup/issues/44).

## Fixed

- Simplified the regex to accept all characters in the system name & env. Hopefully avoiding further interface errors. See [Issue #49](https://github.com/timmyomahony/craft-remote-backup/issues/49)