### PR TITLE
Craft 5 support

### DIFF
--- a/.craftplugin
+++ b/.craftplugin
@@ -1,11 +1,11 @@
 {
     "pluginName": "Crate Remote Backup",
     "pluginDescription": "Backup your database and assets to a remote destination like S3",
-    "pluginVersion": "1.0.0",
+    "pluginVersion": "5.0.0",
     "pluginAuthorName": "Timmy O'Mahony",
     "pluginVendorName": "weareferal",
-    "pluginAuthorUrl": "https://weareferal.com",
-    "pluginAuthorGithub": "weareferal",
+    "pluginAuthorUrl": "https://craft-plugins.timmyomahony.com/remote-backup",
+    "pluginAuthorGithub": "timmyomahony",
     "codeComments": "yes",
     "pluginComponents": [
         "controllers",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased] 5.0.0 - 2024-07-03
+## 5.0.0 - 2024-08-03
+
+### Added
+
+- Craft 5 support.
+
+### Fixed
+
+- Fixed file listing issue with AWS. See Remote Backup [Issue #54](https://github.com/timmyomahony/craft-remote-backup/issues/54) and Remote Core [PR #24](https://github.com/timmyomahony/craft-remote-core/pull/24)
+- Cleaned up logging. See Remote Backup [Issue #59](https://github.com/timmyomahony/craft-remote-backup/issues/59) and Remote Core [PR #25](https://github.com/timmyomahony/craft-remote-core/pull/25)
 
 ## 4.1.6 - 2023-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] 5.0.0 - 2024-07-03
+
 ## 4.1.6 - 2023-12-07
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,4 @@
 {
-    "minimum-stability": "dev",
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../craft-remote-core",
-            "options": {
-                "symlink": true
-            }
-        }
-    ],
     "name": "weareferal/remote-backup",
     "description": "Backup your database and assets to a remote location",
     "type": "craft-plugin",
@@ -33,7 +23,7 @@
     "require": {
         "craftcms/cms": "^5.0.0",
         "php": "^8.0.2",
-        "weareferal/remote-core": "dev-main"
+        "weareferal/remote-core": "5.0.0"
     },
     "require-dev": {
         "phpstan/phpstan": "1.12.x-dev",

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,14 @@
 {
+    "minimum-stability": "dev",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../craft-remote-core",
+            "options": {
+                "symlink": true
+            }
+        }
+    ],
     "name": "weareferal/remote-backup",
     "description": "Backup your database and assets to a remote location",
     "type": "craft-plugin",
@@ -21,12 +31,12 @@
         }
     ],
     "require": {
-        "craftcms/cms": "^4.0.0",
+        "craftcms/cms": "^5.0.0",
         "php": "^8.0.2",
-        "weareferal/remote-core": "4.1.2"
+        "weareferal/remote-core": "dev-main"
     },
     "require-dev": {
-        "phpstan/phpstan": "1.8.x-dev",
+        "phpstan/phpstan": "1.12.x-dev",
         "craftcms/phpstan": "dev-main",
         "craftcms/rector": "dev-main"
     },

--- a/src/RemoteBackup.php
+++ b/src/RemoteBackup.php
@@ -122,7 +122,7 @@ class RemoteBackup extends Plugin
         if ($this->getSettings()->enabled) {
             Event::on(
                 Utilities::class,
-                Utilities::EVENT_REGISTER_UTILITY_TYPES,
+                Utilities::EVENT_REGISTER_UTILITIES,
                 function (RegisterComponentTypesEvent $event) {
                     $event->types[] = RemoteBackupUtility::class;
                 }

--- a/src/controllers/RemoteBackupController.php
+++ b/src/controllers/RemoteBackupController.php
@@ -53,6 +53,7 @@ class RemoteBackupController extends Controller
                 "success" => true
             ]);
         } catch (\Exception $e) {
+            Craft::error($e->getTraceAsString(), __METHOD__);
             return $this->asFailure(
                 Craft::t('remote-backup', 'Test failed'),
                 [

--- a/src/templates/utilities/remote-backup.html
+++ b/src/templates/utilities/remote-backup.html
@@ -2,12 +2,12 @@
 
 {% if not isConfigured %}
     <div class="field">
-        <p class="warning"><strong>{{ 'Plugin settings have not been configured yet'|t('remote-backup') }}</strong></p>
+        <p class="warning">{{ 'Plugin settings have not been configured yet'|t('remote-backup') }}</p>
     </div>
 {% else %}
     {% if not isAuthenticated %}
         <div class="field">
-            <p class="warning"><strong>{{ 'You need to authenticate with your provider. Please visit the plugin settings page.'|t('remote-backup') }}</strong></p>
+            <p class="warning">{{ 'You need to authenticate with your provider. Please visit the plugin settings page.'|t('remote-backup') }}</p>
         </div>
     {% else %}
         {% if queueActive %}

--- a/src/utilities/RemoteBackupUtility.php
+++ b/src/utilities/RemoteBackupUtility.php
@@ -21,7 +21,7 @@ class RemoteBackupUtility extends Utility
         return 'remote-backup';
     }
 
-    public static function iconPath(): string|null
+    public static function icon(): string|null
     {
         return RemoteBackup::getInstance()->getBasePath() . DIRECTORY_SEPARATOR . 'utility-icon.svg';
     }


### PR DESCRIPTION
### Added

- Craft 5 support.

### Fixed

- Fixed file listing issue with AWS. See Remote Backup [Issue #54](https://github.com/timmyomahony/craft-remote-backup/issues/54) and Remote Core [PR #24](https://github.com/timmyomahony/craft-remote-core/pull/24)
- Cleaned up logging. See Remote Backup [Issue #59](https://github.com/timmyomahony/craft-remote-backup/issues/59) and Remote Core [PR #25](https://github.com/timmyomahony/craft-remote-core/pull/25)